### PR TITLE
Improve using ThreadLocalRandom

### DIFF
--- a/src/main/java/org/javaunit/autoparams/ObjectGenerator.java
+++ b/src/main/java/org/javaunit/autoparams/ObjectGenerator.java
@@ -1,11 +1,11 @@
 package org.javaunit.autoparams;
 
 import java.util.Optional;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 interface ObjectGenerator {
 
-    static final Random RANDOM = new Random();
+    ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
 
     Optional<Object> generate(ObjectQuery query, ObjectGenerationContext context);
 


### PR DESCRIPTION
Random 클래스 대신, JDK 7부터 추가된 ThreadLocalRandom 클래스를 사용하도록 개선합니다.

Random 클래스와 ThreadLocalRandom 둘다 thread-safe하며, 내부 구현에 차이로 ThreadLocalRandom이 더 나은 성능을 제공합니다. 

https://all4dev.blogspot.com/2020/04/java-random-vs-threadlocalrandom-performance.html
http://cr.openjdk.java.net/~iris/se/13/spec/latest/api/java.base/java/util/concurrent/ThreadLocalRandom.html