### PR TITLE
Refactor ObjectGenerationContext

### DIFF
--- a/src/main/java/org/javaunit/autoparams/ArrayGenerator.java
+++ b/src/main/java/org/javaunit/autoparams/ArrayGenerator.java
@@ -24,7 +24,7 @@ final class ArrayGenerator implements ObjectGenerator {
     }
 
     private void set(Object array, int index, ObjectQuery query, ObjectGenerationContext context) {
-        context.getGenerator().generate(query, context).ifPresent(element -> Array.set(array, index, element));
+        context.generate(query).ifPresent(element -> Array.set(array, index, element));
     }
 
 }

--- a/src/main/java/org/javaunit/autoparams/CollectionGenerator.java
+++ b/src/main/java/org/javaunit/autoparams/CollectionGenerator.java
@@ -26,10 +26,9 @@ final class CollectionGenerator extends GenericObjectGenerator {
     public static <T> ArrayList<T> factory(Class<? extends T> componentType, ObjectGenerationContext context) {
         ArrayList<T> instance = new ArrayList<T>();
         int size = 3;
-        ObjectGenerator generator = context.getGenerator();
         ObjectQuery query = new ObjectQuery(componentType);
         for (int i = 0; i < size; i++) {
-            generator.generate(query, context).map(x -> (T) x).ifPresent(instance::add);
+            context.generate(query).map(x -> (T) x).ifPresent(instance::add);
         }
 
         return instance;

--- a/src/main/java/org/javaunit/autoparams/ComplexObjectGenerator.java
+++ b/src/main/java/org/javaunit/autoparams/ComplexObjectGenerator.java
@@ -85,8 +85,7 @@ final class ComplexObjectGenerator implements ObjectGenerator {
     }
 
     private Object[] generateArguments(Stream<ObjectQuery> argumentQueries, ObjectGenerationContext context) {
-        ObjectGenerator generator = context.getGenerator();
-        return argumentQueries.map(query -> generator.generate(query, context)).map(a -> a.orElse(null)).toArray();
+        return argumentQueries.map(context::generate).map(a -> a.orElse(null)).toArray();
     }
 
 }

--- a/src/main/java/org/javaunit/autoparams/MapGenerator.java
+++ b/src/main/java/org/javaunit/autoparams/MapGenerator.java
@@ -25,12 +25,11 @@ final class MapGenerator extends GenericObjectGenerator {
             ObjectGenerationContext context) {
         HashMap<K, V> instance = new HashMap<K, V>();
         int size = 3;
-        ObjectGenerator generator = context.getGenerator();
         ObjectQuery keyQuery = new ObjectQuery(keyType);
         ObjectQuery valueQuery = new ObjectQuery(valueType);
         for (int i = 0; i < size; i++) {
-            generator.generate(keyQuery, context).map(x -> (K) x).ifPresent(
-                    k -> generator.generate(valueQuery, context).map(x -> (V) x).ifPresent(v -> instance.put(k, v)));
+            context.generate(keyQuery).map(x -> (K) x).ifPresent(
+                    k -> context.generate(valueQuery).map(x -> (V) x).ifPresent(v -> instance.put(k, v)));
         }
 
         return instance;

--- a/src/main/java/org/javaunit/autoparams/ObjectGenerationContext.java
+++ b/src/main/java/org/javaunit/autoparams/ObjectGenerationContext.java
@@ -1,5 +1,7 @@
 package org.javaunit.autoparams;
 
+import java.util.Optional;
+
 final class ObjectGenerationContext {
 
     private final ObjectGenerator generator;
@@ -9,8 +11,8 @@ final class ObjectGenerationContext {
 
     }
 
-    public ObjectGenerator getGenerator() {
-        return generator;
+    public Optional<Object> generate(ObjectQuery query) {
+        return generator.generate(query, this);
     }
 
 }

--- a/src/main/java/org/javaunit/autoparams/SetGenerator.java
+++ b/src/main/java/org/javaunit/autoparams/SetGenerator.java
@@ -24,10 +24,9 @@ final class SetGenerator extends GenericObjectGenerator {
     public static <T> HashSet<T> factory(Class<? extends T> componentType, ObjectGenerationContext context) {
         HashSet<T> instance = new HashSet<T>();
         int size = 3;
-        ObjectGenerator generator = context.getGenerator();
         ObjectQuery query = new ObjectQuery(componentType);
         for (int i = 0; i < size; i++) {
-            generator.generate(query, context).map(x -> (T) x).ifPresent(instance::add);
+            context.generate(query).map(x -> (T) x).ifPresent(instance::add);
         }
 
         return instance;


### PR DESCRIPTION
deletes the getGenerator method and introduces the new generate method
to simplify.


------------------------------

This closes #30 