### PR TITLE
SimpleType 체크로직 개선

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/ComplexObjectConstructorResolver.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ComplexObjectConstructorResolver.java
@@ -3,7 +3,9 @@ package org.javaunit.autoparams;
 import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 final class ComplexObjectConstructorResolver {
@@ -14,10 +16,12 @@ final class ComplexObjectConstructorResolver {
             : Arrays.stream(type.getConstructors()).findFirst();
     }
 
+    private static Set<Class<?>> SIMPLE_TYPES = new HashSet<>(
+        Arrays.asList(Boolean.class, Integer.class, Long.class, Float.class, Double.class,
+            String.class, BigDecimal.class, UUID.class));
+
     private static boolean isSimpleType(Class<?> type) {
-        return type.equals(Boolean.class) || type.equals(Integer.class) || type.equals(Long.class)
-            || type.equals(Float.class) || type.equals(Double.class) || type.equals(String.class)
-            || type.equals(BigDecimal.class) || type.equals(UUID.class);
+        return SIMPLE_TYPES.stream().anyMatch(type::equals);
     }
 
 }


### PR DESCRIPTION
- type.equals()비교 연산이 반복적으로 수행되고 있어 이를 별도의 static 변수화 한 후 판단 로직을 간소화 함