### PR TITLE
Delete the isSimpleType method

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/ComplexObjectConstructorResolver.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ComplexObjectConstructorResolver.java
@@ -16,17 +16,13 @@ final class ComplexObjectConstructorResolver {
     }
 
     public static Optional<Constructor<?>> resolveConstructor(Class<?> type) {
-        return selectConstructor(type.getConstructors());
-    }
-
-    private static Optional<Constructor<?>> selectConstructor(Constructor<?>[] constructors) {
         ConstructorSelector[] selectors = new ConstructorSelector[] {
             source -> selectWithFewestParameters(filterDecoratedWithConstructorProperties(source)),
             source -> selectWithFewestParameters(source),
         };
 
         for (ConstructorSelector selector : selectors) {
-            Optional<Constructor<?>> constructor = selector.select(constructors);
+            Optional<Constructor<?>> constructor = selector.select(type.getConstructors());
             if (constructor.isPresent()) {
                 return constructor;
             }

--- a/autoparams/src/main/java/org/javaunit/autoparams/ComplexObjectConstructorResolver.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ComplexObjectConstructorResolver.java
@@ -4,13 +4,8 @@ import static java.util.Arrays.stream;
 
 import java.beans.ConstructorProperties;
 import java.lang.reflect.Constructor;
-import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
 
 final class ComplexObjectConstructorResolver {
 
@@ -21,17 +16,7 @@ final class ComplexObjectConstructorResolver {
     }
 
     public static Optional<Constructor<?>> resolveConstructor(Class<?> type) {
-        return isSimpleType(type)
-            ? Optional.empty()
-            : selectConstructor(type.getConstructors());
-    }
-
-    private static final Set<Class<?>> SIMPLE_TYPES = new HashSet<>(
-        Arrays.asList(Boolean.class, Integer.class, Long.class, Float.class, Double.class,
-            String.class, BigDecimal.class, UUID.class));
-
-    private static boolean isSimpleType(Class<?> type) {
-        return SIMPLE_TYPES.stream().anyMatch(type::equals);
+        return selectConstructor(type.getConstructors());
     }
 
     private static Optional<Constructor<?>> selectConstructor(Constructor<?>[] constructors) {
@@ -62,8 +47,8 @@ final class ComplexObjectConstructorResolver {
         Constructor<?>[] constructors) {
 
         return stream(constructors)
-           .filter(c -> c.isAnnotationPresent(ConstructorProperties.class))
-           .toArray(Constructor<?>[]::new);
+            .filter(c -> c.isAnnotationPresent(ConstructorProperties.class))
+            .toArray(Constructor<?>[]::new);
     }
 
 }


### PR DESCRIPTION
The isSimpleType check is unnecessary as generating simples types are
considered before than complex types.