### PR TITLE
Gradle test depends on editorconfigCheck

### DIFF
--- a/autoparams/build.gradle
+++ b/autoparams/build.gradle
@@ -19,7 +19,7 @@ java {
 }
 
 test {
-    dependsOn('checkstyleMain', 'checkstyleTest')
+    dependsOn('editorconfigCheck', 'checkstyleMain', 'checkstyleTest')
 
     useJUnitPlatform()
 }


### PR DESCRIPTION
아래 케이스에 따라 gradle test 실행시 `editorconfigCheck` 를 의존하도록 한다.

https://github.com/JavaUnit/AutoParams/pull/78#issuecomment-802639393