### PR TITLE
Refactor: Do not use the option type.

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/ArrayGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ArrayGenerator.java
@@ -17,14 +17,10 @@ final class ArrayGenerator implements ObjectGenerator {
         Object array = Array.newInstance(componentType, length);
         ObjectQuery query = new ObjectQuery(componentType);
         for (int i = 0; i < length; i++) {
-            set(array, i, query, context);
+            Array.set(array, i, context.generate(query));
         }
 
         return Optional.of(array);
-    }
-
-    private void set(Object array, int index, ObjectQuery query, ObjectGenerationContext context) {
-        context.generate(query).ifPresent(element -> Array.set(array, index, element));
     }
 
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/AutoArgumentsProvider.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/AutoArgumentsProvider.java
@@ -70,7 +70,7 @@ final class AutoArgumentsProvider implements ArgumentsProvider,
 
     private Object createArgument(Parameter parameter) {
         ObjectQuery query = ObjectQuery.create(parameter);
-        return context.generate(query).orElse(null);
+        return context.generate(query);
     }
 
     @Override

--- a/autoparams/src/main/java/org/javaunit/autoparams/CollectionGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/CollectionGenerator.java
@@ -23,7 +23,7 @@ final class CollectionGenerator extends GenericObjectGenerator {
         int size = 3;
         ObjectQuery query = new ObjectQuery(componentType);
         for (int i = 0; i < size; i++) {
-            context.generate(query).map(x -> (T) x).ifPresent(instance::add);
+            instance.add((T) context.generate(query));
         }
 
         return instance;

--- a/autoparams/src/main/java/org/javaunit/autoparams/ComplexObjectGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ComplexObjectGenerator.java
@@ -100,7 +100,7 @@ final class ComplexObjectGenerator implements ObjectGenerator {
     private Object[] generateArguments(
         Stream<ObjectQuery> argumentQueries, ObjectGenerationContext context) {
 
-        return argumentQueries.map(context::generate).map(a -> a.orElse(null)).toArray();
+        return argumentQueries.map(context::generate).toArray();
     }
 
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/MapGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/MapGenerator.java
@@ -31,9 +31,8 @@ final class MapGenerator extends GenericObjectGenerator {
         ObjectQuery keyQuery = new ObjectQuery(keyType);
         ObjectQuery valueQuery = new ObjectQuery(valueType);
         for (int i = 0; i < size; i++) {
-            context.generate(keyQuery).map(x -> (K) x).ifPresent(
-                k -> context.generate(valueQuery).map(x -> (V) x)
-                    .ifPresent(v -> instance.put(k, v)));
+            instance.put(
+                (K) context.generate(keyQuery), (V) context.generate(valueQuery));
         }
 
         return instance;

--- a/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerationContext.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerationContext.java
@@ -12,6 +12,6 @@ final class ObjectGenerationContext {
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     public Object generate(ObjectQuery query) {
         // This generate method always assumes that it can create values with a given query.
-        return generator.generate(query, this).get();
+        return generator.generate(query, this).get(); // TODO: Use the orElseThrow method.
     }
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerationContext.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerationContext.java
@@ -1,7 +1,5 @@
 package org.javaunit.autoparams;
 
-import java.util.Optional;
-
 final class ObjectGenerationContext {
 
     private final ObjectGenerator generator;
@@ -11,8 +9,9 @@ final class ObjectGenerationContext {
 
     }
 
-    public Optional<Object> generate(ObjectQuery query) {
-        return generator.generate(query, this);
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    public Object generate(ObjectQuery query) {
+        // This generate method always assumes that it can create values with a given query.
+        return generator.generate(query, this).get();
     }
-
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/SetGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/SetGenerator.java
@@ -18,7 +18,7 @@ final class SetGenerator extends GenericObjectGenerator {
         int size = 3;
         ObjectQuery query = new ObjectQuery(componentType);
         for (int i = 0; i < size; i++) {
-            context.generate(query).map(x -> (T) x).ifPresent(instance::add);
+            instance.add((T) context.generate(query));
         }
 
         return instance;


### PR DESCRIPTION
ObjectGenerationContext always assumes that it can create values with a
given query, so it is unnecessary to use the option type.