### PR TITLE
Refactor EnumValueResolver with EnumSet.allOf 

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/EnumValuesResolver.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/EnumValuesResolver.java
@@ -1,6 +1,6 @@
 package org.javaunit.autoparams;
 
-import java.lang.reflect.InvocationTargetException;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -8,16 +8,8 @@ final class EnumValuesResolver {
 
     private static final Map<Class<?>, Object[]> CACHE = new ConcurrentHashMap<>();
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public static Object[] resolveValues(Class<?> type) {
-        return CACHE.computeIfAbsent(type, EnumValuesResolver::getValues);
+        return CACHE.computeIfAbsent(type, it -> EnumSet.allOf((Class<Enum>) it).toArray());
     }
-
-    private static Object[] getValues(Class<?> type) {
-        try {
-            return (Object[]) type.getDeclaredMethod("values").invoke(null);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
 }


### PR DESCRIPTION
EnumValueResolver 가 불필요해서 제거합니다.
Enum 값 생성은 `EnumSet.allOf` 로 대체합니다.