### PR TITLE
Introduce the GenerationResult class

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/Builder.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/Builder.java
@@ -33,4 +33,5 @@ public final class Builder<T> {
             return new ObjectQuery((Class<?>) generateType);
         }
     }
+
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/CompositeObjectGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/CompositeObjectGenerator.java
@@ -26,11 +26,11 @@ final class CompositeObjectGenerator implements ObjectGenerator {
     public GenerationResult generateObject(ObjectQuery query, ObjectGenerationContext context) {
         for (ObjectGenerator generator : generators) {
             GenerationResult result = generator.generateObject(query, context);
-            if (result.isSuccess()) {
+            if (result.isPresent()) {
                 return result;
             }
         }
 
-        return GenerationResult.failure();
+        return GenerationResult.absence();
     }
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/CompositeObjectGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/CompositeObjectGenerator.java
@@ -22,4 +22,15 @@ final class CompositeObjectGenerator implements ObjectGenerator {
         return Optional.empty();
     }
 
+    @Override
+    public GenerationResult generateObject(ObjectQuery query, ObjectGenerationContext context) {
+        for (ObjectGenerator generator : generators) {
+            GenerationResult result = generator.generateObject(query, context);
+            if (result.isSuccess()) {
+                return result;
+            }
+        }
+
+        return GenerationResult.failure();
+    }
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/GenerationResult.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/GenerationResult.java
@@ -1,0 +1,33 @@
+package org.javaunit.autoparams;
+
+final class GenerationResult {
+
+    private static final GenerationResult FAILURE = new GenerationResult(null);
+
+    private final Object value;
+
+    private GenerationResult(Object value) {
+        this.value = value;
+    }
+
+    public Object get() {
+        return value;
+    }
+
+    public boolean isSuccess() {
+        return this != FAILURE;
+    }
+
+    public boolean isFailure() {
+        return this == FAILURE;
+    }
+
+    public static GenerationResult success(Object result) {
+        return new GenerationResult(result);
+    }
+
+    public static GenerationResult failure() {
+        return FAILURE;
+    }
+
+}

--- a/autoparams/src/main/java/org/javaunit/autoparams/GenerationResult.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/GenerationResult.java
@@ -4,7 +4,7 @@ import javax.annotation.Nullable;
 
 final class GenerationResult {
 
-    private static final GenerationResult FAILURE = new GenerationResult(null);
+    private static final GenerationResult ABSENCE = new GenerationResult(null);
 
     @Nullable
     private final Object value;
@@ -18,20 +18,20 @@ final class GenerationResult {
         return value;
     }
 
-    public boolean isSuccess() {
-        return this != FAILURE;
+    public boolean isPresent() {
+        return !this.isAbsent();
     }
 
-    public boolean isFailure() {
-        return this == FAILURE;
+    public boolean isAbsent() {
+        return this == ABSENCE;
     }
 
-    public static GenerationResult success(Object result) {
-        return new GenerationResult(result);
+    public static GenerationResult presence(Object value) {
+        return new GenerationResult(value);
     }
 
-    public static GenerationResult failure() {
-        return FAILURE;
+    public static GenerationResult absence() {
+        return ABSENCE;
     }
 
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/GenerationResult.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/GenerationResult.java
@@ -1,15 +1,19 @@
 package org.javaunit.autoparams;
 
+import javax.annotation.Nullable;
+
 final class GenerationResult {
 
     private static final GenerationResult FAILURE = new GenerationResult(null);
 
+    @Nullable
     private final Object value;
 
-    private GenerationResult(Object value) {
+    private GenerationResult(@Nullable Object value) {
         this.value = value;
     }
 
+    @Nullable
     public Object get() {
         return value;
     }

--- a/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerationContext.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerationContext.java
@@ -10,11 +10,15 @@ final class ObjectGenerationContext {
     }
 
     public Object generate(ObjectQuery query) {
-        return generator.generate(query, this).orElseThrow(() -> {
+        GenerationResult result = generator.generateObject(query, this);
+        if (result.isFailure()) {
             String format = "An object cannot be generated with the given query '%s'. "
                 + "This can happen if the query represents an interface or abstract class.";
 
-            return new ObjectGenerationException(String.format(format, query.getType()));
-        });
+            throw new ObjectGenerationException(String.format(format, query.getType()));
+        }
+
+        return result.get();
     }
+
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerationContext.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerationContext.java
@@ -14,7 +14,7 @@ final class ObjectGenerationContext {
     @Nullable
     public Object generate(ObjectQuery query) {
         GenerationResult result = generator.generateObject(query, this);
-        if (result.isFailure()) {
+        if (result.isAbsent()) {
             String format = "An object cannot be generated with the given query '%s'. "
                 + "This can happen if the query represents an interface or abstract class.";
 

--- a/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerationContext.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerationContext.java
@@ -1,5 +1,7 @@
 package org.javaunit.autoparams;
 
+import javax.annotation.Nullable;
+
 final class ObjectGenerationContext {
 
     private final ObjectGenerator generator;
@@ -9,6 +11,7 @@ final class ObjectGenerationContext {
 
     }
 
+    @Nullable
     public Object generate(ObjectQuery query) {
         GenerationResult result = generator.generateObject(query, this);
         if (result.isFailure()) {

--- a/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerator.java
@@ -7,6 +7,19 @@ interface ObjectGenerator {
 
     ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
 
+    /**
+     * This method generates an arbitrary object with the given query.
+     *
+     * @deprecated This method will be deleted, so don't implement it, but implement
+     *     the {@link ObjectGenerator#generateObject(ObjectQuery, ObjectGenerationContext)} method
+     *     instead.
+     */
     Optional<Object> generate(ObjectQuery query, ObjectGenerationContext context);
+
+    default GenerationResult generateObject(ObjectQuery query, ObjectGenerationContext context) {
+        return this.generate(query, context)
+            .map(GenerationResult::success)
+            .orElseGet(GenerationResult::failure);
+    }
 
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerator.java
@@ -7,13 +7,6 @@ interface ObjectGenerator {
 
     ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
 
-    /**
-     * This method generates an arbitrary object with the given query.
-     *
-     * @deprecated This method will be deleted, so don't implement it, but implement
-     *     the {@link ObjectGenerator#generateObject(ObjectQuery, ObjectGenerationContext)} method
-     *     instead.
-     */
     Optional<Object> generate(ObjectQuery query, ObjectGenerationContext context);
 
     default GenerationResult generateObject(ObjectQuery query, ObjectGenerationContext context) {

--- a/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerator.java
@@ -11,8 +11,8 @@ interface ObjectGenerator {
 
     default GenerationResult generateObject(ObjectQuery query, ObjectGenerationContext context) {
         return this.generate(query, context)
-            .map(GenerationResult::success)
-            .orElseGet(GenerationResult::failure);
+            .map(GenerationResult::presence)
+            .orElseGet(GenerationResult::absence);
     }
 
 }


### PR DESCRIPTION
This introduces the new GenerationResult class as the optional type
cannot represent the three cases: empty/null/non-null.


----------------------------------------

#98 이슈 처리를 위한 첫 작업입니다. 전체 작업리스트는 여기 https://github.com/JavaUnit/AutoParams/issues/98#issue-837597654 를 참고하실 수 있습니다.