### PR TITLE
Fix warning in ObjectGenerationException class

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerationException.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ObjectGenerationException.java
@@ -1,7 +1,11 @@
 package org.javaunit.autoparams;
 
 public final class ObjectGenerationException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
     ObjectGenerationException(String message) {
         super(message);
     }
+
 }


### PR DESCRIPTION
The detail message of the warning:

The serializable class ObjectGenerationException does not declare a
static final serialVersionUID field of type longJava(536871008)