### PR TITLE
Rewrite test to repeat property

### DIFF
--- a/autoparams/src/test/java/org/javaunit/autoparams/AutoArgumentsProviderSpecs.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/AutoArgumentsProviderSpecs.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -19,7 +18,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 public class AutoArgumentsProviderSpecs {
 
@@ -34,31 +32,6 @@ public class AutoArgumentsProviderSpecs {
     }
 
     public void hasSingleParameter(int a) {
-    }
-
-    @Test
-    void sut_creates_single_set() throws Exception {
-        AutoArgumentsProvider sut = new AutoArgumentsProvider();
-        ExtensionContext context = mock(ExtensionContext.class);
-        when(context.getTestMethod()).thenReturn(Optional.of(getMethod("hasSingleParameter")));
-
-        List<Arguments> actual = sut.provideArguments(context).collect(Collectors.toList());
-
-        assertThat(actual.size()).isEqualTo(1);
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {1, 2, 10})
-    void sut_applies_repeat(int repeat) throws Exception {
-        AutoArgumentsProvider sut = new AutoArgumentsProvider();
-        AutoSource annotation = mock(AutoSource.class);
-        when(annotation.repeat()).thenReturn(repeat);
-        ExtensionContext context = getExtensionContext("hasSingleParameter");
-
-        sut.accept(annotation);
-
-        Stream<? extends Arguments> actual = sut.provideArguments(context);
-        assertThat(actual.toArray()).hasSize(repeat);
     }
 
     public void hasTwoParameters(int a0, int a1) {

--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForRepeatProperty.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForRepeatProperty.java
@@ -1,0 +1,43 @@
+package org.javaunit.autoparams.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.javaunit.autoparams.AutoSource;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+
+@TestMethodOrder(OrderAnnotation.class)
+public class SpecsForRepeatProperty {
+
+    private static int count = 0;
+
+    @ParameterizedTest
+    @AutoSource()
+    @Order(1)
+    void run() {
+        count++;
+    }
+
+    @Test
+    @Order(2)
+    void if_repeat_property_not_specified_sut_executes_test_just_one_time() {
+        assertEquals(1, count);
+    }
+
+    @ParameterizedTest
+    @AutoSource(repeat = 3)
+    @Order(3)
+    void repeat_run() {
+        count++;
+    }
+
+    @Test
+    @Order(4)
+    void if_repeat_property_specified_sut_executes_test_repeatedly() {
+        assertEquals(1 + 3, count);
+    }
+
+}


### PR DESCRIPTION
Introduce org.javaunit.autoparams.test package that cannot access
package-private code of production packages to decouple production code
and test code.