### PR TITLE
Reduce possibility of false-positive

### DIFF
--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForPrimitiveTypes.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForPrimitiveTypes.java
@@ -21,7 +21,17 @@ class SpecsForPrimitiveTypes {
         boolean value7,
         boolean value8,
         boolean value9,
-        boolean value10
+        boolean value10,
+        boolean value11,
+        boolean value12,
+        boolean value13,
+        boolean value14,
+        boolean value15,
+        boolean value16,
+        boolean value17,
+        boolean value18,
+        boolean value19,
+        boolean value20
     ) {
         HashSet<Boolean> set = new HashSet<Boolean>();
         set.add(value1);
@@ -34,6 +44,16 @@ class SpecsForPrimitiveTypes {
         set.add(value8);
         set.add(value9);
         set.add(value10);
+        set.add(value11);
+        set.add(value12);
+        set.add(value13);
+        set.add(value14);
+        set.add(value15);
+        set.add(value16);
+        set.add(value17);
+        set.add(value18);
+        set.add(value19);
+        set.add(value20);
         assertThat(set).hasSize(2);
     }
 
@@ -49,7 +69,17 @@ class SpecsForPrimitiveTypes {
         Boolean value7,
         Boolean value8,
         Boolean value9,
-        Boolean value10
+        Boolean value10,
+        Boolean value11,
+        Boolean value12,
+        Boolean value13,
+        Boolean value14,
+        Boolean value15,
+        Boolean value16,
+        Boolean value17,
+        Boolean value18,
+        Boolean value19,
+        Boolean value20
     ) {
         HashSet<Boolean> set = new HashSet<Boolean>();
         set.add(value1);
@@ -62,6 +92,16 @@ class SpecsForPrimitiveTypes {
         set.add(value8);
         set.add(value9);
         set.add(value10);
+        set.add(value11);
+        set.add(value12);
+        set.add(value13);
+        set.add(value14);
+        set.add(value15);
+        set.add(value16);
+        set.add(value17);
+        set.add(value18);
+        set.add(value19);
+        set.add(value20);
         assertThat(set).hasSize(2);
     }
 


### PR DESCRIPTION
Occasionally false-positives occur in tests for boolean types. Increase
the test data to reduce this possibility.