### PR TITLE
Add @CsvAutoSource annotation

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/ArgumentsAssembler.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ArgumentsAssembler.java
@@ -1,0 +1,55 @@
+package org.javaunit.autoparams;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+final class ArgumentsAssembler {
+
+    public static Stream<? extends Arguments> assembleArguments(
+        ExtensionContext context,
+        ArgumentsProvider... providers
+    ) {
+        return foldl(
+            (sets, provider) -> sets.flatMap(set -> supplementArguments(set, provider, context)),
+            Stream.of(Arguments.of()),
+            Arrays.stream(providers));
+    }
+
+    private static <T, U> U foldl(BiFunction<U, T, U> f, U z, Stream<T> xs) {
+        Iterator<T> i = xs.iterator();
+        U a = z;
+        while (i.hasNext()) {
+            a = f.apply(a, i.next());
+        }
+        return a;
+    }
+
+    private static Stream<? extends Arguments> supplementArguments(
+        Arguments source,
+        ArgumentsProvider provider,
+        ExtensionContext context
+    ) {
+        try {
+            return provider
+                .provideArguments(context)
+                .map(supplement -> supplementArguments(source, supplement));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Arguments supplementArguments(Arguments source, Arguments supplement) {
+        ArrayList<Object> arguments = new ArrayList<Object>();
+        Collections.addAll(arguments, source.get());
+        Arrays.stream(supplement.get()).skip(arguments.size()).forEach(arguments::add);
+        return Arguments.of(arguments.toArray());
+    }
+
+}

--- a/autoparams/src/main/java/org/javaunit/autoparams/ArgumentsProviderCreator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ArgumentsProviderCreator.java
@@ -1,0 +1,24 @@
+package org.javaunit.autoparams;
+
+import java.lang.reflect.AccessibleObject;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+final class ArgumentsProviderCreator {
+
+    public static ArgumentsProvider createProvider(Class<?> sourceType) {
+        ArgumentsSource source = sourceType.getAnnotation(ArgumentsSource.class);
+        Class<? extends ArgumentsProvider> providerType = source.value();
+        try {
+            return makeAccessible(providerType.getDeclaredConstructor()).newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static <T extends AccessibleObject> T makeAccessible(T object) {
+        object.setAccessible(true);
+        return object;
+    }
+
+}

--- a/autoparams/src/main/java/org/javaunit/autoparams/AutoArgumentsProvider.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/AutoArgumentsProvider.java
@@ -10,8 +10,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.AnnotationConsumer;
 
-final class AutoArgumentsProvider implements ArgumentsProvider,
-    AnnotationConsumer<AutoSource> {
+final class AutoArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<AutoSource> {
 
     private static final Stream<Arguments> EMPTY = stream(new Arguments[0]);
 

--- a/autoparams/src/main/java/org/javaunit/autoparams/CsvAutoArgumentsProvider.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/CsvAutoArgumentsProvider.java
@@ -1,0 +1,68 @@
+package org.javaunit.autoparams;
+
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+
+final class CsvAutoArgumentsProvider implements
+    ArgumentsProvider,
+    AnnotationConsumer<CsvAutoSource> {
+
+    private final ArgumentsProvider csvProvider;
+    private final AutoArgumentsProvider autoProvider;
+
+    public CsvAutoArgumentsProvider() {
+        csvProvider = ArgumentsProviderCreator.createProvider(CsvSource.class);
+        autoProvider = new AutoArgumentsProvider();
+    }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+        return ArgumentsAssembler.assembleArguments(context, csvProvider, autoProvider);
+    }
+
+    private static CsvSource createDelegate(CsvAutoSource source) {
+        return new CsvSource() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return CsvSource.class;
+            }
+
+            @Override
+            public String[] value() {
+                return source.value();
+            }
+
+            @Override
+            public char delimiter() {
+                return '\0';
+            }
+
+            @Override
+            public String delimiterString() {
+                return "";
+            }
+
+            @Override
+            public String emptyValue() {
+                return "";
+            }
+
+            @Override
+            public String[] nullValues() {
+                return new String[] {};
+            }
+        };
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void accept(CsvAutoSource annotation) {
+        ((AnnotationConsumer<CsvSource>) csvProvider).accept(createDelegate(annotation));
+    }
+
+}

--- a/autoparams/src/main/java/org/javaunit/autoparams/CsvAutoSource.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/CsvAutoSource.java
@@ -1,0 +1,14 @@
+package org.javaunit.autoparams;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ArgumentsSource(CsvAutoArgumentsProvider.class)
+public @interface CsvAutoSource {
+    String[] value();
+}

--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForCsvAutoSource.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForCsvAutoSource.java
@@ -1,0 +1,40 @@
+package org.javaunit.autoparams.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.UUID;
+import org.javaunit.autoparams.CsvAutoSource;
+import org.junit.jupiter.params.ParameterizedTest;
+
+class SpecsForCsvAutoSource {
+
+    @ParameterizedTest
+    @CsvAutoSource({"1, foo"})
+    void sut_correctly_fills_arguments(int value1, String value2) {
+        assertEquals(1, value1);
+        assertEquals("foo", value2);
+    }
+
+    @ParameterizedTest
+    @CsvAutoSource({"1, foo"})
+    void sut_correctly_fills_forepart_arguments(int value1, String value2, UUID value3) {
+        assertEquals(1, value1);
+        assertEquals("foo", value2);
+    }
+
+    @ParameterizedTest
+    @CsvAutoSource({"1, foo"})
+    void sut_arbitrarily_generates_remaining_arguments(
+        int value1,
+        String value2,
+        UUID value3,
+        UUID value4
+    ) {
+        assertNotNull(value3);
+        assertNotNull(value4);
+        assertNotEquals(value3, value4);
+    }
+
+}


### PR DESCRIPTION
@CsvAutoSource combines functionalities of @CsvSource and @AutoSource.
It fulfils the test arguments using @CsvSource first then resolves
the unfilled arguments with the implementation of @AutoSource.

This resolves #17