### PR TITLE
Introduce public ObjectQuery interface

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/generator/ObjectQuery.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/generator/ObjectQuery.java
@@ -1,0 +1,9 @@
+package org.javaunit.autoparams.generator;
+
+import java.lang.reflect.Type;
+
+public interface ObjectQuery {
+
+    Type getType();
+
+}


### PR DESCRIPTION
ObjectQuery interface represents the request to generate an object. It
is a root type of a variety of object query types.