### PR TITLE
Gradle Publications 설정값을 gradle.properties 로 이동

### DIFF
--- a/autoparams/gradle.properties
+++ b/autoparams/gradle.properties
@@ -1,0 +1,3 @@
+artifactId=autoparams
+artifactName=AutoParams
+artifactDescription=Arbitrary test data generator for parameterized tests in Java.

--- a/build.gradle
+++ b/build.gradle
@@ -84,11 +84,11 @@ subprojects {
 
         publications {
             maven(MavenPublication) {
-                artifactId 'autoparams'
+                artifactId artifactId
                 from components.java
                 pom {
-                    name = "AutoParams"
-                    description = "Arbitrary test data generator for parameterized tests in Java."
+                    name = artifactName
+                    description = artifactDescription
                     url = "https://github.com/JavaUnit/AutoParams"
                     licenses {
                         license {


### PR DESCRIPTION
멀티 모듈에서 publications 각각의 artifactId 및 pom 내용을 적용하기 위해 gradle.properties 로 설정값을 분리합니다.