### PR TITLE
Include the maximum value specified by @Max

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/generator/IntegerGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/generator/IntegerGenerator.java
@@ -12,8 +12,8 @@ final class IntegerGenerator implements ObjectGenerator {
         Type type = query.getType();
         if (type == int.class || type == Integer.class) {
             int origin = getOrigin(query);
-            int maximum = getMaximum(query);
-            int value = ThreadLocalRandom.current().nextInt(origin, maximum);
+            int bound = getBound(query);
+            int value = ThreadLocalRandom.current().nextInt(origin, bound);
             return new ObjectContainer(value);
         }
 
@@ -32,12 +32,12 @@ final class IntegerGenerator implements ObjectGenerator {
         return Integer.MIN_VALUE;
     }
 
-    private int getMaximum(ObjectQuery query) {
+    private int getBound(ObjectQuery query) {
         if (query instanceof ArgumentQuery) {
             ArgumentQuery argumentQuery = (ArgumentQuery) query;
             Max annotation = argumentQuery.getParameter().getAnnotation(Max.class);
             if (annotation != null) {
-                return (int) Math.min(Integer.MAX_VALUE, annotation.value());
+                return (int) Math.min(Integer.MAX_VALUE, annotation.value() + 1);
             }
         }
 

--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForMax.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForMax.java
@@ -1,6 +1,7 @@
 package org.javaunit.autoparams.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -19,6 +20,12 @@ public class SpecsForMax {
     @AutoSource(repeat = 100)
     void sut_accepts_max_constraint_with_big_value_for_int(@Min(0) @Max(0x80000000L) int value) {
         assertThat(value).isGreaterThanOrEqualTo(0);
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    void sut_includes_maximum_value(@Min(1) @Max(1) int value) {
+        assertEquals(1, value);
     }
 
 }


### PR DESCRIPTION
Fix the bug that @AutoSource excludes the maximum value specified by
@Max annotation when generates int values.