### PR TITLE
Jar 에 MANIFEST.INF 정보를 포함한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,19 @@ subprojects {
 
     tasks.getByPath("spotbugsMain").finalizedBy("printSpotbugsMain")
 
+    jar {
+        manifest {
+            attributes(
+                    'Implementation-Title': artifactName,
+                    'Implementation-Version': artifactVersion,
+                    'Implementation-Vendor': group,
+                    'Specification-Title': artifactName,
+                    'Specification-Version': artifactVersion,
+                    'Specification-Vendor': group
+            )
+        }
+    }
+
     publishing {
         repositories {
             maven {


### PR DESCRIPTION
#214 

Gradle 에서 Jar 로 만들 때 메타데이터를 포함한 MANIFEST.MF 가 생성되도록 한다.