### PR TITLE
Support @Max constraint for parameter of long

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/generator/LongGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/generator/LongGenerator.java
@@ -2,6 +2,7 @@ package org.javaunit.autoparams.generator;
 
 import java.lang.reflect.Type;
 import java.util.concurrent.ThreadLocalRandom;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 final class LongGenerator implements ObjectGenerator {
@@ -11,11 +12,24 @@ final class LongGenerator implements ObjectGenerator {
         Type type = query.getType();
         if (type == long.class || type == Long.class) {
             long origin = getOrigin(query);
-            long value = ThreadLocalRandom.current().nextLong(origin, Long.MAX_VALUE);
+            long bound = getBound(query);
+            long value = ThreadLocalRandom.current().nextLong(origin, bound);
             return new ObjectContainer(value);
         }
 
         return ObjectContainer.EMPTY;
+    }
+
+    private long getBound(ObjectQuery query) {
+        if (query instanceof ArgumentQuery) {
+            ArgumentQuery argumentQuery = (ArgumentQuery) query;
+            Max annotation = argumentQuery.getParameter().getAnnotation(Max.class);
+            if (annotation != null) {
+                return annotation.value();
+            }
+        }
+
+        return Long.MAX_VALUE;
     }
 
     private long getOrigin(ObjectQuery query) {

--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForMax.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForMax.java
@@ -33,4 +33,10 @@ public class SpecsForMax {
     void sut_accepts_max_constraint_for_double(@Max(100) double value) {
         assertThat(value).isLessThanOrEqualTo(100);
     }
+
+    @ParameterizedTest
+    @AutoSource(repeat = 100)
+    void sut_accepts_max_constraint_for_long(@Max(100) long value) {
+        assertThat(value).isLessThanOrEqualTo(100);
+    }
 }


### PR DESCRIPTION
resolves #191 
리뷰 부탁드립니다. 🙇 

추가적으로 질문 있습니다.
- DoubleGenerator 클래스의 메서드에 관한 질문입니다.
```
    private double getOrigin(ObjectQuery query) {
        if (query instanceof ArgumentQuery) {
            ArgumentQuery argumentQuery = (ArgumentQuery) query;
            Min annotation = argumentQuery.getParameter().getAnnotation(Min.class);
            if (annotation != null) {
                return (double) Math.max(Double.MIN_VALUE, annotation.value());
            }
        }

        return Double.MIN_VALUE;
    }
```
return 부분이 이렇게 바뀌어야 하는거 아닐까요?
```
  return (double)annotation.value();
```