### PR TITLE
SpecsForEnum 테스트 Assertion 수정

### DIFF
--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForEnum.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForEnum.java
@@ -53,7 +53,7 @@ class SpecsForEnum {
         set.add(value18);
         set.add(value19);
         set.add(value20);
-        assertThat(set).contains(EnumType.values());
+        assertThat(EnumType.values()).containsAll(set);
     }
 
 }


### PR DESCRIPTION
- 생성된 Enum value 가 Elements 종류를 모두 포함하지 않을 경우 테스트가 실패한다.
- 생성된 값들이 Enum Elements 의 부분집합인지 검사하도록 수정한다.

resolves #225 