### PR TITLE
Fix IntegerGenerator Bug

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/generator/IntegerGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/generator/IntegerGenerator.java
@@ -13,6 +13,9 @@ final class IntegerGenerator implements ObjectGenerator {
         if (type == int.class || type == Integer.class) {
             int origin = getOrigin(query);
             int bound = getBound(query);
+            if (origin == bound) {
+                return new ObjectContainer(origin);
+            }
             int value = ThreadLocalRandom.current().nextInt(origin, bound);
             return new ObjectContainer(value);
         }
@@ -25,7 +28,8 @@ final class IntegerGenerator implements ObjectGenerator {
             ArgumentQuery argumentQuery = (ArgumentQuery) query;
             Min annotation = argumentQuery.getParameter().getAnnotation(Min.class);
             if (annotation != null) {
-                return (int) Math.max(Integer.MIN_VALUE, annotation.value());
+                long value = Math.min(Integer.MAX_VALUE, annotation.value());
+                return (int) Math.max(Integer.MIN_VALUE, value);
             }
         }
 
@@ -37,7 +41,11 @@ final class IntegerGenerator implements ObjectGenerator {
             ArgumentQuery argumentQuery = (ArgumentQuery) query;
             Max annotation = argumentQuery.getParameter().getAnnotation(Max.class);
             if (annotation != null) {
-                return (int) Math.min(Integer.MAX_VALUE, annotation.value() + 1);
+                long value = Math.max(Integer.MIN_VALUE, annotation.value());
+                if (value < Long.MAX_VALUE) {
+                    value = value + 1;
+                }
+                return (int) Math.min(Integer.MAX_VALUE, value);
             }
         }
 

--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForMax.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForMax.java
@@ -39,4 +39,16 @@ public class SpecsForMax {
     void sut_accepts_max_constraint_for_long(@Max(100) long value) {
         assertThat(value).isLessThanOrEqualTo(100);
     }
+
+    @ParameterizedTest
+    @AutoSource(repeat = 100)
+    void sut_accepts_max_constraint_for_int_when_over_lower_bound(@Max(Long.MIN_VALUE) int value) {
+        assertThat(value).isEqualTo(Integer.MIN_VALUE);
+    }
+
+    @ParameterizedTest
+    @AutoSource(repeat = 100)
+    void sut_accepts_max_constraint_for_int_when_over_upper_bound(@Max(Long.MAX_VALUE) int value) {
+        assertThat(value).isLessThanOrEqualTo(Integer.MAX_VALUE);
+    }
 }

--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForMin.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForMin.java
@@ -26,4 +26,16 @@ public class SpecsForMin {
         assertThat(value).isGreaterThanOrEqualTo(100);
     }
 
+    @ParameterizedTest
+    @AutoSource(repeat = 100)
+    void sut_accepts_min_constraint_for_int_when_over_upper_bound(@Min(Long.MAX_VALUE) int value) {
+        assertThat(value).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @ParameterizedTest
+    @AutoSource(repeat = 100)
+    void sut_accepts_min_constraint_for_int_when_over_lower_bound(@Min(Long.MIN_VALUE) int value) {
+        assertThat(value).isGreaterThanOrEqualTo(Integer.MIN_VALUE);
+    }
+
 }


### PR DESCRIPTION
resolves #220

구체적으로는 아래와 같은 이슈들을 해결했습니다.
- fix overFlow issue when min is greater than Integer.MAX_VALUE
- fix overFlow issue when max is lower than Integer.MIN_VALUE
- fix overFlow issue when max is  Long.MAX_VALUE

아직도 잔존하는 이슈
- @Max값이 Integer.MAX_VALUE 보다 같거나 크면 랜덤 Integer 생성시 Integer.MAX_VALUE 값은 상실상 랜덤 생성시 제외됨
 (@Min(Integer.MAX_VALUE) @Max(Integer.MAX_VALUE) 방법으로는  가능)

많이 부족한 실력이지만 나름 해결해 보았습니다. 
잔존하는 이슈는 IntegerGenerator 뿐만아니라 다른 모든 숫자 Generator가 가지고 있는 이슈로 보입니다.  이부분을 어떻게 해결해야 할지 판단이  서지 않아 그냥 두었습니다.
리뷰후 피드백 부탁드리겠습니다. 🙇 