### PR TITLE
MockitoCustomizer ignores primitive types

### DIFF
--- a/autoparams-mockito/src/main/java/org/javaunit/autoparams/mockito/MockitoCustomizer.java
+++ b/autoparams-mockito/src/main/java/org/javaunit/autoparams/mockito/MockitoCustomizer.java
@@ -33,7 +33,8 @@ public final class MockitoCustomizer implements Customizer {
     }
 
     private boolean isAbstract(Class<?> type) {
-        return type.isInterface() || Modifier.isAbstract(type.getModifiers());
+        return type.isInterface()
+            || (type.isPrimitive() == false && Modifier.isAbstract(type.getModifiers()));
     }
 
 }

--- a/autoparams-mockito/src/test/java/org/javaunit/autoparams/mockito/test/SpecsForMockitoCustomizer.java
+++ b/autoparams-mockito/src/test/java/org/javaunit/autoparams/mockito/test/SpecsForMockitoCustomizer.java
@@ -39,4 +39,10 @@ class SpecsForMockitoCustomizer {
         assertNotNull(value);
     }
 
+    @ParameterizedTest
+    @AutoSource
+    @Customization(MockitoCustomizer.class)
+    void sut_ignores_parameters_of_primitive_types(int arg1, double arg2) {
+    }
+
 }


### PR DESCRIPTION
`int` 등 기본 형식 매개변수를 가진 테스트 메서드에 `MockitiCustomizer`를 사용할 때 실패하는 문제를 해결한다.