### PR TITLE
Introduce ArgumentProcessor interface

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/ArgumentsGenerator.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/ArgumentsGenerator.java
@@ -64,19 +64,14 @@ final class ArgumentsGenerator {
 
     private Arguments createArguments(Method method) {
         Parameter[] parameters = method.getParameters();
-        Object[] arguments = Arrays.stream(parameters).map(this::createArgument).toArray();
-        return Arguments.of(arguments);
+        Stream<Object> arguments = Arrays.stream(parameters).map(this::createThenProcessArgument);
+        return Arguments.of(arguments.toArray());
     }
 
-    private Object createArgument(Parameter parameter) {
+    private Object createThenProcessArgument(Parameter parameter) {
         customizeGenerator(parameter);
-
         Object argument = context.generate(ObjectQuery.fromParameter(parameter));
-
-        if (parameter.isAnnotationPresent(Fixed.class)) {
-            context.customizeGenerator(new FixCustomization(parameter.getType(), argument));
-        }
-
+        Customizers.processArgument(parameter, argument).forEach(context::customizeGenerator);
         return argument;
     }
 

--- a/autoparams/src/main/java/org/javaunit/autoparams/Customizers.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/Customizers.java
@@ -1,8 +1,13 @@
 package org.javaunit.autoparams;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Parameter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
+import org.javaunit.autoparams.customization.ArgumentProcessing;
 import org.javaunit.autoparams.customization.Customizer;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
@@ -25,6 +30,29 @@ final class Customizers {
             Customizers.class,
             k -> new ArrayList<Customizer>(),
             List.class);
+    }
+
+    static Stream<Customizer> processArgument(Parameter parameter, Object argument) {
+        return Arrays
+            .stream(parameter.getAnnotations())
+            .map(Annotation::annotationType)
+            .flatMap(type -> Arrays.stream(type.getAnnotationsByType(ArgumentProcessing.class)))
+            .map(ArgumentProcessing::value)
+            .map(Customizers::createInstance)
+            .map(processor -> processor.process(parameter, argument));
+    }
+
+    private static <T> T createInstance(Class<? extends T> type) {
+        try {
+            return type.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException
+            | IllegalAccessException
+            | IllegalArgumentException
+            | InvocationTargetException
+            | NoSuchMethodException
+            | SecurityException exception) {
+            throw new RuntimeException(exception);
+        }
     }
 
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/Fixed.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/Fixed.java
@@ -4,8 +4,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.javaunit.autoparams.customization.ArgumentProcessing;
 
 @Target({ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
+@ArgumentProcessing(FixedArgumentProcessor.class)
 public @interface Fixed {
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/FixedArgumentProcessor.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/FixedArgumentProcessor.java
@@ -1,0 +1,14 @@
+package org.javaunit.autoparams;
+
+import java.lang.reflect.Parameter;
+import org.javaunit.autoparams.customization.ArgumentProcessor;
+import org.javaunit.autoparams.customization.Customizer;
+
+final class FixedArgumentProcessor implements ArgumentProcessor {
+
+    @Override
+    public Customizer process(Parameter parameter, Object argument) {
+        return new FixCustomization(parameter.getType(), argument);
+    }
+
+}

--- a/autoparams/src/main/java/org/javaunit/autoparams/customization/ArgumentProcessing.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/customization/ArgumentProcessing.java
@@ -1,0 +1,14 @@
+package org.javaunit.autoparams.customization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ArgumentProcessing {
+
+    Class<? extends ArgumentProcessor> value();
+
+}

--- a/autoparams/src/main/java/org/javaunit/autoparams/customization/ArgumentProcessor.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/customization/ArgumentProcessor.java
@@ -1,0 +1,9 @@
+package org.javaunit.autoparams.customization;
+
+import java.lang.reflect.Parameter;
+
+public interface ArgumentProcessor {
+
+    Customizer process(Parameter parameter, Object argument);
+
+}


### PR DESCRIPTION
ArgumentProcessor represents the functionality to generate Customizer
with parameter and argument. ArgumentsAssembler and ArgumentsGenerator
support it.

The behavior of @Fixed annotation is rewritten using ArgumentProcessor
so that ArgumentsAssembler and ArgumentsGenerator do not depend on
@Fixed annotation.