### PR TITLE
Introduce InstanceFieldWriter

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/customization/InstanceFieldWriter.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/customization/InstanceFieldWriter.java
@@ -1,0 +1,100 @@
+package org.javaunit.autoparams.customization;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.function.Predicate;
+import org.javaunit.autoparams.generator.ObjectContainer;
+import org.javaunit.autoparams.generator.ObjectGenerationContext;
+import org.javaunit.autoparams.generator.ObjectGenerator;
+
+public final class InstanceFieldWriter implements Customizer {
+
+    private final Class<?> targetType;
+    private final Predicate<Field> predicate;
+
+    public InstanceFieldWriter(Class<?> targetType) {
+        this(targetType, x -> true);
+    }
+
+    private InstanceFieldWriter(Class<?> targetType, Predicate<Field> predicate) {
+        this.targetType = targetType;
+        this.predicate = predicate;
+    }
+
+    @Override
+    public ObjectGenerator customize(ObjectGenerator generator) {
+        return (query, context) -> {
+            ObjectContainer container = generator.generate(query, context);
+            Type underlyingType = query.getType();
+            return getRawType(underlyingType) == targetType
+                ? container.process(target -> process(target, underlyingType, context))
+                : container;
+        };
+    }
+
+    private Class<?> getRawType(Type type) {
+        return type instanceof ParameterizedType
+            ? (Class<?>) ((ParameterizedType) type).getRawType()
+            : (Class<?>) type;
+    }
+
+    private Object process(Object target, Type underlyingType, ObjectGenerationContext context) {
+        writeAllFields(target, underlyingType, context);
+        return target;
+    }
+
+    private void writeAllFields(
+        Object target,
+        Type underlyingType,
+        ObjectGenerationContext context
+    ) {
+        writeFields(target, underlyingType, context, RuntimeTypeResolver.create(underlyingType));
+        Type superType = getRawType(underlyingType).getGenericSuperclass();
+        if (superType != null) {
+            writeAllFields(target, superType, context);
+        }
+    }
+
+    private void writeFields(
+        Object target,
+        Type genericType,
+        ObjectGenerationContext context,
+        RuntimeTypeResolver typeResolver
+    ) {
+        Arrays
+            .stream(getRawType(genericType).getDeclaredFields())
+            .filter(InstanceFieldWriter::isNonStatic)
+            .filter(predicate)
+            .forEach(field -> writeField(target, field, context, typeResolver));
+    }
+
+    private static boolean isNonStatic(Field field) {
+        return Modifier.isStatic(field.getModifiers()) == false;
+    }
+
+    private void writeField(
+        Object target,
+        Field field,
+        ObjectGenerationContext context,
+        RuntimeTypeResolver typeResolver
+    ) {
+        field.setAccessible(true);
+        Type type = typeResolver.resolve(field.getGenericType());
+        Object argument = context.generate(() -> type);
+        try {
+            field.set(target, argument);
+        } catch (IllegalArgumentException | IllegalAccessException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    public InstanceFieldWriter excluding(String... fieldNames) {
+        return new InstanceFieldWriter(
+            targetType,
+            field -> Arrays.stream(fieldNames).anyMatch(x -> field.getName().equals(x)) == false);
+    }
+
+}

--- a/autoparams/src/main/java/org/javaunit/autoparams/customization/RuntimeTypeResolver.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/customization/RuntimeTypeResolver.java
@@ -1,0 +1,75 @@
+package org.javaunit.autoparams.customization;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+final class RuntimeTypeResolver {
+
+    private Map<TypeVariable<?>, Type> map;
+
+    private RuntimeTypeResolver(Map<TypeVariable<?>, Type> map) {
+        this.map = map;
+    }
+
+    public static RuntimeTypeResolver create(Type source) {
+        return new RuntimeTypeResolver(source instanceof ParameterizedType
+            ? buildMap((ParameterizedType) source)
+            : Collections.emptyMap());
+    }
+
+    public static Map<TypeVariable<?>, Type> buildMap(ParameterizedType parameterizedType) {
+        Class<?> rawType = (Class<?>) parameterizedType.getRawType();
+        TypeVariable<?>[] typeVariables = rawType.getTypeParameters();
+
+        Type[] typeValues = parameterizedType.getActualTypeArguments();
+
+        HashMap<TypeVariable<?>, Type> map = new HashMap<>();
+        for (int i = 0; i < typeVariables.length; i++) {
+            map.put(typeVariables[i], typeValues[i]);
+        }
+
+        return map;
+    }
+
+    public Type resolve(Type type) {
+        if (map.containsKey(type)) {
+            return map.get(type);
+        } else if (type instanceof ParameterizedType) {
+            return resolve((ParameterizedType) type);
+        } else {
+            return type;
+        }
+    }
+
+    private Type resolve(ParameterizedType parameterizedType) {
+        Type[] typeArguments = parameterizedType.getActualTypeArguments();
+
+        for (int i = 0; i < typeArguments.length; i++) {
+            typeArguments[i] = resolve(typeArguments[i]);
+        }
+
+        return new ParameterizedType() {
+
+            @Override
+            public Type[] getActualTypeArguments() {
+                return typeArguments.clone();
+            }
+
+            @Override
+            public Type getRawType() {
+                return resolve(parameterizedType.getRawType());
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return resolve(parameterizedType.getOwnerType());
+            }
+
+        };
+    }
+
+}

--- a/autoparams/src/test/java/org/javaunit/autoparams/customization/test/Entity.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/customization/test/Entity.java
@@ -1,0 +1,11 @@
+package org.javaunit.autoparams.customization.test;
+
+public class Entity<T> extends Versioned {
+
+    private T id;
+
+    public T getId() {
+        return id;
+    }
+
+}

--- a/autoparams/src/test/java/org/javaunit/autoparams/customization/test/Inventory.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/customization/test/Inventory.java
@@ -1,0 +1,18 @@
+package org.javaunit.autoparams.customization.test;
+
+import java.util.ArrayList;
+
+public class Inventory<T> {
+
+    private int capacity;
+    private ArrayList<T> items;
+
+    public int getCapacity() {
+        return capacity;
+    }
+
+    public Iterable<T> getItems() {
+        return items;
+    }
+
+}

--- a/autoparams/src/test/java/org/javaunit/autoparams/customization/test/SpecsForInstanceFieldWriter.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/customization/test/SpecsForInstanceFieldWriter.java
@@ -1,0 +1,70 @@
+package org.javaunit.autoparams.customization.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.javaunit.autoparams.AutoSource;
+import org.javaunit.autoparams.customization.CompositeCustomizer;
+import org.javaunit.autoparams.customization.Customization;
+import org.javaunit.autoparams.customization.InstanceFieldWriter;
+import org.junit.jupiter.params.ParameterizedTest;
+
+class SpecsForInstanceFieldWriter {
+
+    public static class DomainCustomizer extends CompositeCustomizer {
+        public DomainCustomizer() {
+            super(
+                new InstanceFieldWriter(Versioned.class),
+                new InstanceFieldWriter(Entity.class),
+                new InstanceFieldWriter(User.class),
+                new InstanceFieldWriter(Worker.class).excluding("activeWorks", "closedWorks"),
+                new InstanceFieldWriter(Inventory.class));
+        }
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    @Customization(DomainCustomizer.class)
+    void sut_sets_fields(Versioned versioned) {
+        assertNotNull(versioned.getVersion());
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    @Customization(DomainCustomizer.class)
+    void sut_sets_fields_of_generic_class(Entity<Long> entity) {
+        assertNotNull(entity.getId());
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    @Customization(DomainCustomizer.class)
+    void sut_sets_fields_of_generic_type(Inventory<Entity<Long>> inventory) {
+        assertNotNull(inventory.getItems());
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    @Customization(DomainCustomizer.class)
+    void sut_sets_inherited_fields(Worker worker) {
+        assertNotNull(worker.getId());
+        assertNotNull(worker.getUsername());
+        assertNotNull(worker.getTeamName());
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    @Customization(DomainCustomizer.class)
+    void sut_does_not_set_static_fields(User user) {
+        assertEquals("hello world", User.getDefaultGreeting());
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    @Customization(DomainCustomizer.class)
+    void sut_does_not_set_excluded_fields(Worker worker) {
+        assertEquals(0, worker.getActiveWorks());
+        assertEquals(0, worker.getClosedWorks());
+    }
+
+}

--- a/autoparams/src/test/java/org/javaunit/autoparams/customization/test/User.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/customization/test/User.java
@@ -1,0 +1,17 @@
+package org.javaunit.autoparams.customization.test;
+
+public class User extends Entity<Long> {
+
+    private static String defaultGreeting = "hello world";
+
+    private String username;
+
+    public static String getDefaultGreeting() {
+        return defaultGreeting;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+}

--- a/autoparams/src/test/java/org/javaunit/autoparams/customization/test/Versioned.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/customization/test/Versioned.java
@@ -1,0 +1,11 @@
+package org.javaunit.autoparams.customization.test;
+
+public class Versioned {
+
+    private long version;
+
+    public long getVersion() {
+        return version;
+    }
+
+}

--- a/autoparams/src/test/java/org/javaunit/autoparams/customization/test/Worker.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/customization/test/Worker.java
@@ -1,0 +1,29 @@
+package org.javaunit.autoparams.customization.test;
+
+public class Worker extends User {
+
+    private String teamName;
+    private int activeWorks;
+    private int closedWorks;
+
+    public String getTeamName() {
+        return teamName;
+    }
+
+    public int getActiveWorks() {
+        return activeWorks;
+    }
+
+    public void setActiveWorks(int activeWorks) {
+        this.activeWorks = activeWorks;
+    }
+
+    public int getClosedWorks() {
+        return closedWorks;
+    }
+
+    public void setClosedWorks(int closedWorks) {
+        this.closedWorks = closedWorks;
+    }
+
+}


### PR DESCRIPTION
InstanceFieldWriter sets instance fields including inherited fields. You
can exclude some fields with excluding method.