### PR TITLE
Add including method to InstanceFieldWriter

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/customization/InstanceFieldWriter.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/customization/InstanceFieldWriter.java
@@ -1,10 +1,11 @@
 package org.javaunit.autoparams.customization;
 
+import static java.util.Arrays.stream;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Arrays;
 import java.util.function.Predicate;
 import org.javaunit.autoparams.generator.ObjectContainer;
 import org.javaunit.autoparams.generator.ObjectGenerationContext;
@@ -64,8 +65,7 @@ public final class InstanceFieldWriter implements Customizer {
         ObjectGenerationContext context,
         RuntimeTypeResolver typeResolver
     ) {
-        Arrays
-            .stream(getRawType(genericType).getDeclaredFields())
+        stream(getRawType(genericType).getDeclaredFields())
             .filter(InstanceFieldWriter::isNonStatic)
             .filter(predicate)
             .forEach(field -> writeField(target, field, context, typeResolver));
@@ -91,10 +91,17 @@ public final class InstanceFieldWriter implements Customizer {
         }
     }
 
+    public InstanceFieldWriter including(String... fieldNames) {
+        return new InstanceFieldWriter(
+            targetType,
+            predicate.and(field -> stream(fieldNames).anyMatch(x -> field.getName().equals(x))));
+    }
+
     public InstanceFieldWriter excluding(String... fieldNames) {
         return new InstanceFieldWriter(
             targetType,
-            field -> Arrays.stream(fieldNames).anyMatch(x -> field.getName().equals(x)) == false);
+            predicate.and(field ->
+                stream(fieldNames).allMatch(x -> field.getName().equals(x) == false)));
     }
 
 }

--- a/autoparams/src/test/java/org/javaunit/autoparams/customization/test/Operator.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/customization/test/Operator.java
@@ -1,0 +1,11 @@
+package org.javaunit.autoparams.customization.test;
+
+public class Operator extends Worker {
+
+    private String phoneNumber;
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+}

--- a/autoparams/src/test/java/org/javaunit/autoparams/customization/test/SpecsForInstanceFieldWriter.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/customization/test/SpecsForInstanceFieldWriter.java
@@ -2,11 +2,13 @@ package org.javaunit.autoparams.customization.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.javaunit.autoparams.AutoSource;
 import org.javaunit.autoparams.customization.CompositeCustomizer;
 import org.javaunit.autoparams.customization.Customization;
 import org.javaunit.autoparams.customization.InstanceFieldWriter;
+import org.javaunit.autoparams.generator.ObjectGenerationContext;
 import org.junit.jupiter.params.ParameterizedTest;
 
 class SpecsForInstanceFieldWriter {
@@ -18,6 +20,7 @@ class SpecsForInstanceFieldWriter {
                 new InstanceFieldWriter(Entity.class),
                 new InstanceFieldWriter(User.class),
                 new InstanceFieldWriter(Worker.class).excluding("activeWorks", "closedWorks"),
+                new InstanceFieldWriter(Operator.class).including("teamName", "phoneNumber"),
                 new InstanceFieldWriter(Inventory.class));
         }
     }
@@ -65,6 +68,52 @@ class SpecsForInstanceFieldWriter {
     void sut_does_not_set_excluded_fields(Worker worker) {
         assertEquals(0, worker.getActiveWorks());
         assertEquals(0, worker.getClosedWorks());
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    @Customization(DomainCustomizer.class)
+    void sut_sets_only_included_fields(Operator operator) {
+        assertNotNull(operator.getTeamName());
+        assertNotNull(operator.getPhoneNumber());
+        assertEquals(0, operator.getActiveWorks());
+        assertEquals(0, operator.getClosedWorks());
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    void including_accumulates_conditions(ObjectGenerationContext context) {
+        // Arrange
+        InstanceFieldWriter sut = new InstanceFieldWriter(Operator.class)
+            .excluding("activeWorks")
+            .including("teamName", "activeWorks");
+
+        context.customizeGenerator(sut);
+
+        // Act
+        Operator actual = (Operator) context.generate(() -> Operator.class);
+
+        // Assert
+        assertNotNull(actual.getTeamName());
+        assertEquals(0, actual.getActiveWorks());
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    void excluding_accumulates_conditions(ObjectGenerationContext context) {
+        // Arrange
+        InstanceFieldWriter sut = new InstanceFieldWriter(Operator.class)
+            .including("teamName", "activeWorks")
+            .excluding("activeWorks");
+
+        context.customizeGenerator(sut);
+
+        // Act
+        Operator actual = (Operator) context.generate(() -> Operator.class);
+
+        // Assert
+        assertNull(actual.getPhoneNumber());
+        assertEquals(0, actual.getActiveWorks());
     }
 
 }


### PR DESCRIPTION
including method creates new InstanceFieldWriter instance that sets
fields only specified fields. including and excluding methods
accumulates conditions.