### PR TITLE
Introduce @Repeat annotation

### DIFF
--- a/autoparams/src/main/java/org/javaunit/autoparams/AutoArgumentsProvider.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/AutoArgumentsProvider.java
@@ -1,5 +1,8 @@
 package org.javaunit.autoparams;
 
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import java.lang.reflect.Method;
 import java.util.stream.Stream;
 import org.javaunit.autoparams.generator.CompositeObjectGenerator;
 import org.javaunit.autoparams.generator.ObjectGenerationContext;
@@ -30,9 +33,16 @@ final class AutoArgumentsProvider implements ArgumentsProvider, AnnotationConsum
     }
 
     private ArgumentsGenerator createArgumentsGenerator(ExtensionContext context) {
+        final int repeat = getRepeat(context);
         return new ArgumentsGenerator(new ObjectGenerationContext(context, generator), repeat);
     }
 
+    private int getRepeat(ExtensionContext context) {
+        final Method method = context.getRequiredTestMethod();
+        return findAnnotation(method, Repeat.class).map(Repeat::value).orElse(repeat);
+    }
+
+    @SuppressWarnings("deprecation")
     @Override
     public void accept(AutoSource annotation) {
         repeat = annotation.repeat();

--- a/autoparams/src/main/java/org/javaunit/autoparams/AutoSource.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/AutoSource.java
@@ -11,6 +11,12 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 @ArgumentsSource(AutoArgumentsProvider.class)
 public @interface AutoSource {
 
+    /**
+     * This property will be removed. Use @Repeat annotation instead.
+     *
+     * @return Number of times to run the test repeatedly
+     */
+    @Deprecated
     int repeat() default 1;
 
 }

--- a/autoparams/src/main/java/org/javaunit/autoparams/Repeat.java
+++ b/autoparams/src/main/java/org/javaunit/autoparams/Repeat.java
@@ -1,0 +1,14 @@
+package org.javaunit.autoparams;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Repeat {
+
+    int value() default 3;
+
+}

--- a/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForRepeat.java
+++ b/autoparams/src/test/java/org/javaunit/autoparams/test/SpecsForRepeat.java
@@ -1,0 +1,47 @@
+package org.javaunit.autoparams.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.javaunit.autoparams.AutoSource;
+import org.javaunit.autoparams.Repeat;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SpecsForRepeat {
+
+    private static int shouldBe10 = 0;
+    private static int shouldBe3 = 0;
+
+    @ParameterizedTest
+    @AutoSource
+    @Repeat(10)
+    @Order(1)
+    void sut_work_correctly(int x) {
+        shouldBe10++;
+    }
+
+    @Test
+    @Order(2)
+    void verify_sut_work_correctly() {
+        assertEquals(10, shouldBe10);
+    }
+
+    @ParameterizedTest
+    @AutoSource
+    @Repeat
+    @Order(3)
+    void sut_has_default_value() {
+        shouldBe3++;
+    }
+
+    @Test
+    @Order(4)
+    void verify_sut_has_default_value() {
+        assertEquals(3, shouldBe3);
+    }
+
+}


### PR DESCRIPTION
@Repeat annotation replaces repeat property of @AutoSource. Properties
of annotation types are not extensible so repeat property is replaced
with @Repeat annotation and will be removed in a future release.

This resolves #272